### PR TITLE
Send cached metadata to clients when connecting

### DIFF
--- a/MediaSessionWSProvider/MediaBroadcast.cs
+++ b/MediaSessionWSProvider/MediaBroadcast.cs
@@ -9,7 +9,7 @@ namespace MediaSessionWSProvider;
 
 public class MediaBroadcast : WebSocketBehavior
 {
-    private readonly MetadataCache _cache;
+    public MetadataCache? Cache { private get; set; }
 
     private static readonly JsonSerializerOptions _jsonOptions = new()
     {
@@ -17,9 +17,8 @@ public class MediaBroadcast : WebSocketBehavior
         WriteIndented = false
     };
 
-    public MediaBroadcast(MetadataCache cache)
+    public MediaBroadcast()
     {
-        _cache = cache;
     }
 
     protected override void OnOpen()
@@ -27,7 +26,7 @@ public class MediaBroadcast : WebSocketBehavior
         Console.WriteLine($"total client connected {Sessions.Count}");
         Console.WriteLine($"Client connected: {ID}");
 
-        var state = _cache.Last;
+        var state = Cache?.Last;
         if (state != null)
         {
             var envelope = new { type = "metadata", data = state };

--- a/MediaSessionWSProvider/MediaBroadcast.cs
+++ b/MediaSessionWSProvider/MediaBroadcast.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Text.Json;
+using System.Text.Encodings.Web;
+using System.Text.Unicode;
 using WebSocketSharp;
 using WebSocketSharp.Server;
 
@@ -6,10 +9,31 @@ namespace MediaSessionWSProvider;
 
 public class MediaBroadcast : WebSocketBehavior
 {
+    private readonly MetadataCache _cache;
+
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        Encoder = JavaScriptEncoder.Create(UnicodeRanges.BasicLatin, UnicodeRanges.Cyrillic),
+        WriteIndented = false
+    };
+
+    public MediaBroadcast(MetadataCache cache)
+    {
+        _cache = cache;
+    }
+
     protected override void OnOpen()
     {
         Console.WriteLine($"total client connected {Sessions.Count}");
         Console.WriteLine($"Client connected: {ID}");
+
+        var state = _cache.Last;
+        if (state != null)
+        {
+            var envelope = new { type = "metadata", data = state };
+            var json = JsonSerializer.Serialize(envelope, _jsonOptions);
+            Send(json);
+        }
     }
 
     protected override void OnClose(CloseEventArgs e)

--- a/MediaSessionWSProvider/MetadataCache.cs
+++ b/MediaSessionWSProvider/MetadataCache.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace MediaSessionWSProvider;
+
+public class MetadataCache
+{
+    private readonly object _lockObj = new();
+    private Worker.FullMediaState? _last;
+
+    public Worker.FullMediaState? Last
+    {
+        get { lock (_lockObj) { return _last; } }
+    }
+
+    public void Update(Worker.FullMediaState state)
+    {
+        lock (_lockObj)
+        {
+            _last = state;
+        }
+    }
+}

--- a/MediaSessionWSProvider/MetadataCache.cs
+++ b/MediaSessionWSProvider/MetadataCache.cs
@@ -5,14 +5,14 @@ namespace MediaSessionWSProvider;
 public class MetadataCache
 {
     private readonly object _lockObj = new();
-    private Worker.FullMediaState? _last;
+    private FullMediaState? _last;
 
-    public Worker.FullMediaState? Last
+    public FullMediaState? Last
     {
         get { lock (_lockObj) { return _last; } }
     }
 
-    public void Update(Worker.FullMediaState state)
+    public void Update(FullMediaState state)
     {
         lock (_lockObj)
         {

--- a/MediaSessionWSProvider/Program.cs
+++ b/MediaSessionWSProvider/Program.cs
@@ -14,6 +14,7 @@ var host = Host.CreateDefaultBuilder(args)
     {
         services.AddSingleton<SettingsService>();
         services.AddSingleton<FftService>();
+        services.AddSingleton<MetadataCache>();
         services.AddHostedService<Worker>();
     })
     .ConfigureLogging(logging =>

--- a/MediaSessionWSProvider/Worker.cs
+++ b/MediaSessionWSProvider/Worker.cs
@@ -56,7 +56,7 @@ namespace MediaSessionWSProvider
             var linkedToken = linkedCts.Token;
 
             _wsServer = new WebSocketServer("ws://localhost:5001");
-            _wsServer.AddWebSocketService("/ws", () => new MediaBroadcast(_metadataCache));
+            _wsServer.AddWebSocketService<MediaBroadcast>("/ws", () => new MediaBroadcast(_metadataCache));
             _wsServer.KeepClean   = true;
             _wsServer.WaitTime    = TimeSpan.FromSeconds(10);
             _wsServer.Start();

--- a/MediaSessionWSProvider/Worker.cs
+++ b/MediaSessionWSProvider/Worker.cs
@@ -3,6 +3,7 @@ using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using WebSocketSharp.Server;
 using Windows.Media.Control;
+// The Worker manages websocket broadcasting and keeps track of the latest metadata
 
 namespace MediaSessionWSProvider
 {
@@ -12,6 +13,7 @@ namespace MediaSessionWSProvider
         private WebSocketServer _wsServer;
         private GlobalSystemMediaTransportControlsSessionManager _sessionManager;
         private readonly FftService _fftService;
+        private readonly MetadataCache _metadataCache;
 
         private static readonly JsonSerializerOptions _jsonOptions = new()
         {
@@ -19,13 +21,14 @@ namespace MediaSessionWSProvider
             WriteIndented = false
         };
 
-        private FullMediaState _lastFullState;
+        private FullMediaState? _lastFullState;
         private CancellationTokenSource _internalCts = new();
 
-        public Worker(ILogger<Worker> logger, FftService fftService)
+        public Worker(ILogger<Worker> logger, FftService fftService, MetadataCache metadataCache)
         {
             _logger = logger;
             _fftService = fftService;
+            _metadataCache = metadataCache;
             _fftService.SpectrumAvailable += OnSpectrum;
         }
 
@@ -53,7 +56,7 @@ namespace MediaSessionWSProvider
             var linkedToken = linkedCts.Token;
 
             _wsServer = new WebSocketServer("ws://localhost:5001");
-            _wsServer.AddWebSocketService<MediaBroadcast>("/ws");
+            _wsServer.AddWebSocketService("/ws", () => new MediaBroadcast(_metadataCache));
             _wsServer.KeepClean   = true;
             _wsServer.WaitTime    = TimeSpan.FromSeconds(10);
             _wsServer.Start();
@@ -127,6 +130,7 @@ namespace MediaSessionWSProvider
                     return;
                 }
                 _lastFullState = fullState;
+                _metadataCache.Update(fullState);
 
                 var envelope = new { type = "metadata", data = fullState };
                 var json = JsonSerializer.Serialize(envelope, _jsonOptions);

--- a/MediaSessionWSProvider/Worker.cs
+++ b/MediaSessionWSProvider/Worker.cs
@@ -56,7 +56,7 @@ namespace MediaSessionWSProvider
             var linkedToken = linkedCts.Token;
 
             _wsServer = new WebSocketServer("ws://localhost:5001");
-            _wsServer.AddWebSocketService<MediaBroadcast>("/ws", () => new MediaBroadcast(_metadataCache));
+            _wsServer.AddWebSocketService<MediaBroadcast>("/ws", b => b.Cache = _metadataCache);
             _wsServer.KeepClean   = true;
             _wsServer.WaitTime    = TimeSpan.FromSeconds(10);
             _wsServer.Start();


### PR DESCRIPTION
## Summary
- create `MetadataCache` to store the last metadata
- send cached metadata to websocket clients on connection
- update worker to maintain cache and provide it to `MediaBroadcast`
- register `MetadataCache` in program startup

## Testing
- `dotnet build MediaSessionWSProvider/MediaSessionWSProvider.csproj -nologo` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ebb595c88320badf71db348dd668