### PR TITLE
Add NativeMediaSession library skeleton

### DIFF
--- a/MediaSessionWSProvider.sln
+++ b/MediaSessionWSProvider.sln
@@ -2,6 +2,8 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediaSessionWSProvider", "MediaSessionWSProvider\MediaSessionWSProvider.csproj", "{79A3CB7F-4CFC-4890-A1DE-98319961A547}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NativeMediaSession", "NativeMediaSession\NativeMediaSession.csproj", "{B386DF52-8860-442F-82EA-A8388AB624DE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -12,5 +14,9 @@ Global
 		{79A3CB7F-4CFC-4890-A1DE-98319961A547}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{79A3CB7F-4CFC-4890-A1DE-98319961A547}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{79A3CB7F-4CFC-4890-A1DE-98319961A547}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B386DF52-8860-442F-82EA-A8388AB624DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B386DF52-8860-442F-82EA-A8388AB624DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B386DF52-8860-442F-82EA-A8388AB624DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B386DF52-8860-442F-82EA-A8388AB624DE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/NativeMediaSession/AudioService.cs
+++ b/NativeMediaSession/AudioService.cs
@@ -1,0 +1,109 @@
+using NAudio.CoreAudioApi;
+using NAudio.Wave;
+using System.Threading;
+
+namespace NativeMediaSession;
+
+public class AudioService : IDisposable
+{
+    private readonly string _deviceId;
+    private readonly FftPipeline _pipeline;
+    private readonly CallbackDispatcher _dispatcher;
+    private WasapiCapture? _capture;
+    private BufferedWaveProvider? _buffer;
+    private Thread? _worker;
+    private CancellationTokenSource? _cts;
+    private int _bytesPerSample;
+    private int _channels;
+
+    public event Action<float[]>? SpectrumAvailable;
+
+    public AudioService(string deviceId, FftPipeline pipeline, CallbackDispatcher dispatcher)
+    {
+        _deviceId = deviceId;
+        _pipeline = pipeline;
+        _dispatcher = dispatcher;
+        _pipeline.SpectrumAvailable += data => _dispatcher.Enqueue(() => SpectrumAvailable?.Invoke(data));
+    }
+
+    public int Start()
+    {
+        try
+        {
+            var enumerator = new MMDeviceEnumerator();
+            var device = enumerator.GetDevice(_deviceId);
+            _capture = device.DataFlow == DataFlow.Render
+                ? new WasapiLoopbackCapture(device)
+                : new WasapiCapture(device) { ShareMode = AudioClientShareMode.Shared };
+            _buffer = new BufferedWaveProvider(_capture.WaveFormat) { DiscardOnBufferOverflow = true };
+            _capture.DataAvailable += (_, e) => _buffer.AddSamples(e.Buffer, 0, e.BytesRecorded);
+            _capture.StartRecording();
+
+            _bytesPerSample = _capture.WaveFormat.BitsPerSample / 8;
+            _channels = _capture.WaveFormat.Channels;
+            _pipeline.SetSampleRate(_capture.WaveFormat.SampleRate);
+            _pipeline.Start();
+
+            _cts = new CancellationTokenSource();
+            _worker = new Thread(() => WorkerLoop(_cts.Token)) { IsBackground = true };
+            _worker.Start();
+            return 0;
+        }
+        catch
+        {
+            Stop();
+            return -2; // wasapi_error
+        }
+    }
+
+    private void WorkerLoop(CancellationToken token)
+    {
+        if (_buffer == null) return;
+        int hopSize = _pipeline.HopSize;
+        int bytesPerHop = hopSize * _bytesPerSample * _channels;
+        byte[] tempBytes = new byte[bytesPerHop];
+        float[] hopSamples = new float[hopSize];
+        while (!token.IsCancellationRequested)
+        {
+            if (_buffer.BufferedBytes < bytesPerHop)
+            {
+                Thread.Sleep(2);
+                continue;
+            }
+            int bytesRead = _buffer.Read(tempBytes, 0, bytesPerHop);
+            int samplesRead = bytesRead / (_bytesPerSample * _channels);
+            if (samplesRead == 0) continue;
+            for (int i = 0; i < samplesRead; i++)
+            {
+                int pos = i * _bytesPerSample * _channels;
+                float sample = _bytesPerSample switch
+                {
+                    4 => BitConverter.ToSingle(tempBytes, pos),
+                    2 => BitConverter.ToInt16(tempBytes, pos) / 32768f,
+                    _ => 0f
+                };
+                hopSamples[i] = sample;
+            }
+            _pipeline.ProcessHop(hopSamples, samplesRead);
+        }
+    }
+
+    public void Stop()
+    {
+        try
+        {
+            _cts?.Cancel();
+            _worker?.Join();
+            _pipeline.Stop();
+            if (_capture != null)
+            {
+                _capture.StopRecording();
+                _capture.Dispose();
+                _capture = null;
+            }
+        }
+        catch { }
+    }
+
+    public void Dispose() => Stop();
+}

--- a/NativeMediaSession/CallbackDispatcher.cs
+++ b/NativeMediaSession/CallbackDispatcher.cs
@@ -1,0 +1,46 @@
+using System.Collections.Concurrent;
+
+namespace NativeMediaSession;
+
+public class CallbackDispatcher : IDisposable
+{
+    private readonly BlockingCollection<Action> _queue = new();
+    private readonly Thread _worker;
+
+    public CallbackDispatcher()
+    {
+        _worker = new Thread(Loop) { IsBackground = true };
+        _worker.Start();
+    }
+
+    public void Enqueue(Action action)
+    {
+        if (!_queue.IsAddingCompleted)
+            _queue.Add(action);
+    }
+
+    private void Loop()
+    {
+        foreach (var action in _queue.GetConsumingEnumerable())
+        {
+            try
+            {
+                action();
+            }
+            catch
+            {
+                // swallow exceptions
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _queue.CompleteAdding();
+        try
+        {
+            _worker.Join();
+        }
+        catch { }
+    }
+}

--- a/NativeMediaSession/Exports.cs
+++ b/NativeMediaSession/Exports.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using NAudio.CoreAudioApi;
+
+namespace NativeMediaSession;
+
+public static class Exports
+{
+    private static bool _initialized;
+    private static readonly MMDeviceEnumerator _enumerator = new();
+    private static readonly CallbackDispatcher _dispatcher = new();
+    private static string? _deviceId;
+    private static FftConfig _config = new(4096, 256, 256, 32);
+    private static AudioService? _audio;
+    private static FftPipeline? _pipeline;
+    private static readonly List<FftSubscription> _fftSubs = new();
+    private static readonly MetadataCache _metadataCache = new();
+    private static GsmtcService? _gsmtc;
+    private static readonly List<MetadataSubscription> _metaSubs = new();
+
+    private readonly record struct FftConfig(int FftSize, int HopSize, int Columns, int PublishIntervalMs);
+
+    private unsafe struct FftSubscription
+    {
+        public delegate* unmanaged<float*, int, void*, void> Callback;
+        public IntPtr User;
+    }
+
+    private unsafe struct MetadataSubscription
+    {
+        public delegate* unmanaged<byte*, int, void*, void> Callback;
+        public IntPtr User;
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "ms_init")]
+    public static int Init()
+    {
+        _initialized = true;
+        return 0;
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "ms_shutdown")]
+    public static void Shutdown()
+    {
+        StopInternal();
+        GsmtcStopInternal();
+        _enumerator.Dispose();
+        _dispatcher.Dispose();
+        _metaSubs.Clear();
+        _fftSubs.Clear();
+        _initialized = false;
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "ms_list_devices")]
+    public static unsafe int ListDevices(byte** jsonUtf8, int* len)
+    {
+        if (jsonUtf8 == null || len == null) return -4; // invalid_param
+        *jsonUtf8 = (byte*)0;
+        *len = 0;
+        try
+        {
+            var list = new List<object>();
+            foreach (var d in _enumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active))
+                list.Add(new { id = d.ID, name = d.FriendlyName, flow = "render" });
+            foreach (var d in _enumerator.EnumerateAudioEndPoints(DataFlow.Capture, DeviceState.Active))
+                list.Add(new { id = d.ID, name = d.FriendlyName, flow = "capture" });
+            string json = JsonSerializer.Serialize(list);
+            byte[] bytes = Encoding.UTF8.GetBytes(json);
+            byte* ptr = (byte*)Marshal.AllocHGlobal(bytes.Length);
+            Marshal.Copy(bytes, 0, (IntPtr)ptr, bytes.Length);
+            *len = bytes.Length;
+            *jsonUtf8 = ptr;
+            return 0;
+        }
+        catch
+        {
+            return -2; // wasapi_error
+        }
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "ms_free")]
+    public static unsafe void Free(void* p)
+    {
+        if (p != null)
+            Marshal.FreeHGlobal((IntPtr)p);
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "ms_set_device")]
+    public static unsafe int SetDevice(byte* deviceIdUtf8)
+    {
+        if (deviceIdUtf8 == null) return -4;
+        try
+        {
+            string id = Marshal.PtrToStringUTF8((IntPtr)deviceIdUtf8)!;
+            _enumerator.GetDevice(id); // verify
+            _deviceId = id;
+            return 0;
+        }
+        catch
+        {
+            return -1; // no_device
+        }
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "ms_set_fft_params")]
+    public static int SetFftParams(int fftSize, int hopSize, int columns, int publishIntervalMs)
+    {
+        if (fftSize <= 0 || hopSize <= 0 || columns <= 0 || publishIntervalMs <= 0) return -4;
+        if ((fftSize & (fftSize - 1)) != 0) return -4; // fftSize must be power of two
+        if (columns > 256) return -4;
+        _config = new FftConfig(fftSize, hopSize, columns, publishIntervalMs);
+        return 0;
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "ms_start")]
+    public static int Start()
+        => StartInternal();
+
+    private static int StartInternal()
+    {
+        if (_audio != null) return -3;
+        if (string.IsNullOrEmpty(_deviceId)) return -1;
+        try
+        {
+            _pipeline = new FftPipeline(_config.FftSize, _config.HopSize, _config.Columns, _config.PublishIntervalMs);
+            _audio = new AudioService(_deviceId!, _pipeline, _dispatcher);
+            _audio.SpectrumAvailable += OnSpectrum;
+            int res = _audio.Start();
+            if (res != 0)
+            {
+                _audio.SpectrumAvailable -= OnSpectrum;
+                _audio = null;
+                _pipeline = null;
+            }
+            return res;
+        }
+        catch
+        {
+            _audio = null;
+            _pipeline = null;
+            return -2;
+        }
+    }
+
+    private static unsafe void OnSpectrum(float[] data)
+    {
+        foreach (var sub in _fftSubs.ToArray())
+        {
+            int len = data.Length;
+            int byteLen = len * sizeof(float);
+            IntPtr buf = Marshal.AllocHGlobal(byteLen);
+            unsafe
+            {
+                fixed (float* src = data)
+                {
+                    Buffer.MemoryCopy(src, (void*)buf, byteLen, byteLen);
+                }
+                sub.Callback((float*)buf, len, (void*)sub.User);
+            }
+            Marshal.FreeHGlobal(buf);
+        }
+    }
+
+    private static unsafe void OnMetadata(FullMediaState state)
+    {
+        string json = JsonSerializer.Serialize(state);
+        byte[] bytes = Encoding.UTF8.GetBytes(json);
+        foreach (var sub in _metaSubs.ToArray())
+        {
+            IntPtr buf = Marshal.AllocHGlobal(bytes.Length);
+            Marshal.Copy(bytes, 0, buf, bytes.Length);
+            sub.Callback((byte*)buf, bytes.Length, (void*)sub.User);
+            Marshal.FreeHGlobal(buf);
+        }
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "ms_stop")]
+    public static int Stop()
+        => StopInternal();
+
+    private static int StopInternal()
+    {
+        if (_audio == null) return 0;
+        _audio.SpectrumAvailable -= OnSpectrum;
+        _audio.Stop();
+        _audio = null;
+        _pipeline = null;
+        return 0;
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "ms_restart")]
+    public static int Restart()
+    {
+        int r = StopInternal();
+        if (r < 0) return r;
+        return StartInternal();
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "ms_subscribe_fft")]
+    public static unsafe void SubscribeFft(delegate* unmanaged<float*, int, void*, void> cb, void* user)
+    {
+        _fftSubs.Add(new FftSubscription { Callback = cb, User = (IntPtr)user });
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "ms_unsubscribe_fft")]
+    public static unsafe void UnsubscribeFft(delegate* unmanaged<float*, int, void*, void> cb)
+    {
+        _fftSubs.RemoveAll(s => s.Callback == cb);
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "ms_subscribe_metadata")]
+    public static unsafe void SubscribeMetadata(delegate* unmanaged<byte*, int, void*, void> cb, void* user)
+    {
+        _metaSubs.Add(new MetadataSubscription { Callback = cb, User = (IntPtr)user });
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "ms_unsubscribe_metadata")]
+    public static unsafe void UnsubscribeMetadata(delegate* unmanaged<byte*, int, void*, void> cb)
+    {
+        _metaSubs.RemoveAll(s => s.Callback == cb);
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "ms_gsmtc_start")]
+    public static int GsmtcStart()
+    {
+        if (_gsmtc != null) return -3;
+        try
+        {
+            _gsmtc = new GsmtcService(_dispatcher, _metadataCache);
+            _gsmtc.MetadataAvailable += OnMetadata;
+            int res = _gsmtc.Start();
+            if (res != 0)
+            {
+                _gsmtc.MetadataAvailable -= OnMetadata;
+                _gsmtc = null;
+            }
+            return res;
+        }
+        catch
+        {
+            _gsmtc = null;
+            return -5;
+        }
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "ms_gsmtc_stop")]
+    public static int GsmtcStop()
+        => GsmtcStopInternal();
+
+    private static int GsmtcStopInternal()
+    {
+        if (_gsmtc == null) return 0;
+        _gsmtc.MetadataAvailable -= OnMetadata;
+        _gsmtc.Stop();
+        _gsmtc = null;
+        return 0;
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = "ms_gsmtc_get_last")]
+    public static unsafe int GsmtcGetLast(byte** jsonUtf8, int* len)
+    {
+        if (jsonUtf8 == null || len == null) return -4;
+        *jsonUtf8 = (byte*)0;
+        *len = 0;
+        var last = _metadataCache.Last;
+        if (last == null) return 0;
+        try
+        {
+            string json = JsonSerializer.Serialize(last);
+            byte[] bytes = Encoding.UTF8.GetBytes(json);
+            byte* ptr = (byte*)Marshal.AllocHGlobal(bytes.Length);
+            Marshal.Copy(bytes, 0, (IntPtr)ptr, bytes.Length);
+            *len = bytes.Length;
+            *jsonUtf8 = ptr;
+            return 0;
+        }
+        catch
+        {
+            return -5;
+        }
+    }
+}

--- a/NativeMediaSession/FftPipeline.cs
+++ b/NativeMediaSession/FftPipeline.cs
@@ -1,0 +1,142 @@
+using NAudio.Dsp;
+using System.Threading;
+
+namespace NativeMediaSession;
+
+public class FftPipeline : IDisposable
+{
+    private const double DbFloor = -80.0;
+    private readonly int _fftSize;
+    private readonly int _hopSize;
+    private readonly int _columns;
+    private readonly int _publishIntervalMs;
+    private readonly FloatRingBuffer _sampleBuffer;
+    private readonly float[] _fftInput;
+    private readonly Complex[] _fftBuf;
+    private readonly TripleBuffer<float[]> _spectrumBuffer;
+
+    private Timer? _notifyTimer;
+    private int[]? _startBin;
+    private int[]? _endBin;
+    private int _sampleRate;
+
+    public event Action<float[]>? SpectrumAvailable;
+
+    public int HopSize => _hopSize;
+    public int Columns => _columns;
+
+    // band centers copied from original FftService
+    private static readonly double[] _bandCenters =
+    {
+        20, 31, 37, 42, 48, 53, 58, 63, 68, 73, 79, 84, 89, 95, 101, 107, 113, 119, 125, 132, 138, 145, 152, 159, 166, 174, 182,
+        189, 197, 205, 214, 222, 231, 240, 249, 259, 268, 278, 288, 298, 308, 319, 330, 341, 353, 364, 376, 388, 401, 413, 426, 439,
+        453, 466, 480, 495, 509, 524, 539, 555, 570, 587, 603, 620, 637, 654, 672, 690, 708, 727, 746, 766, 785, 806, 826, 847, 869,
+        890, 912, 935, 958, 981, 1005, 1029, 1054, 1079, 1105, 1131, 1157, 1184, 1211, 1239, 1268, 1296, 1326, 1356, 1386, 1417, 1448,
+        1480, 1513, 1546, 1579, 1613, 1648, 1683, 1719, 1755, 1792, 1830, 1868, 1907, 1946, 1986, 2027, 2069, 2111, 2153, 2197, 2241,
+        2286, 2331, 2377, 2424, 2472, 2520, 2569, 2619, 2670, 2721, 2774, 2827, 2880, 2935, 2991, 3047, 3104, 3162, 3221, 3281, 3341,
+        3403, 3465, 3529, 3593, 3658, 3724, 3791, 3860, 3929, 3999, 4070, 4142, 4215, 4289, 4365, 4441, 4519, 4597, 4677, 4758, 4839,
+        4923, 5007, 5092, 5179, 5267, 5356, 5446, 5537, 5630, 5724, 5820, 5916, 6014, 6113, 6214, 6316, 6419, 6524, 6630, 6738, 6847,
+        6957, 7069, 7183, 7298, 7414, 7532, 7652, 7773, 7896, 8020, 8146, 8274, 8403, 8534, 8667, 8802, 8938, 9076, 9215, 9357, 9500,
+        9645, 9792, 9941, 10092, 10244, 10399, 10556, 10714, 10875, 11037, 11202, 11369, 11537, 11708, 11881, 12056, 12234, 12413, 12595,
+        12779, 12965, 13153, 13344, 13537, 13733, 13931, 14131, 14334, 14539, 14747, 14957, 15170, 15385, 15603, 15824, 16047, 16273,
+        16501, 16732, 16966, 17203, 17443, 17685, 17931, 18179, 18430, 18684, 18941, 19201, 19464, 19731, 20000
+    };
+
+    public FftPipeline(int fftSize, int hopSize, int columns, int publishIntervalMs)
+    {
+        if (columns > _bandCenters.Length)
+            throw new ArgumentOutOfRangeException(nameof(columns));
+        _fftSize = fftSize;
+        _hopSize = hopSize;
+        _columns = columns;
+        _publishIntervalMs = publishIntervalMs;
+        _sampleBuffer = new FloatRingBuffer(fftSize * 4);
+        _fftInput = new float[fftSize];
+        _fftBuf = new Complex[fftSize];
+        _spectrumBuffer = new(() => new float[columns]);
+    }
+
+    public void SetSampleRate(int sampleRate)
+    {
+        _sampleRate = sampleRate;
+        CalculateBins();
+    }
+
+    private void CalculateBins()
+    {
+        int halfBins = _fftSize / 2;
+        double binWidth = _sampleRate / (double)_fftSize;
+        _startBin = new int[_columns];
+        _endBin = new int[_columns];
+        for (int b = 0; b < _columns; b++)
+        {
+            double fLo = b == 0 ? 0 : Math.Sqrt(_bandCenters[b - 1] * _bandCenters[b]);
+            double fHi = b == _columns - 1 ? _sampleRate / 2.0 - 1 : Math.Sqrt(_bandCenters[b] * _bandCenters[b + 1]);
+            _startBin[b] = (int)Math.Floor(fLo / binWidth);
+            _endBin[b] = (int)Math.Ceiling(fHi / binWidth);
+            if (_startBin[b] < 0) _startBin[b] = 0;
+            if (_endBin[b] > halfBins) _endBin[b] = halfBins;
+            if (_endBin[b] <= _startBin[b]) _endBin[b] = _startBin[b] + 1;
+        }
+    }
+
+    public void Start()
+    {
+        _notifyTimer = new Timer(_ => NotifySpectrum(), null, 0, _publishIntervalMs);
+    }
+
+    public void Stop()
+    {
+        _notifyTimer?.Dispose();
+        _notifyTimer = null;
+    }
+
+    public void ProcessHop(float[] hop, int count)
+    {
+        _sampleBuffer.Write(hop, 0, count);
+        if (_sampleBuffer.Count < _fftSize) return;
+
+        _sampleBuffer.ReadLatest(_fftInput);
+        for (int i = 0; i < _fftSize; i++)
+        {
+            float windowed = _fftInput[i] * (float)FastFourierTransform.HammingWindow(i, _fftSize);
+            _fftBuf[i].X = windowed;
+            _fftBuf[i].Y = 0;
+        }
+        FastFourierTransform.FFT(true, (int)Math.Log2(_fftSize), _fftBuf);
+
+        var spectrum = _spectrumBuffer.GetWriteBuffer();
+        double masterGain = 2;
+        for (int b = 0; b < _columns; b++)
+        {
+            double sum = 0;
+            int binCnt = 0;
+            for (int j = _startBin![b]; j < _endBin![b]; j++, binCnt++)
+            {
+                double re = _fftBuf[j].X;
+                double im = _fftBuf[j].Y;
+                sum += Math.Sqrt(re * re + im * im);
+            }
+            double lin = binCnt > 0 ? sum / binCnt : 0;
+            double db = 20 * Math.Log10(lin + 1e-20);
+            double clamped = Math.Max(db, DbFloor);
+            double norm = (double)(b + 10) / (_columns + 10);
+            double gain = Math.Pow(norm, 0.35);
+            spectrum[b] = (float)(((clamped - DbFloor) / -DbFloor) * gain * masterGain);
+        }
+        _spectrumBuffer.Publish();
+    }
+
+    private void NotifySpectrum()
+    {
+        float[] data = _spectrumBuffer.GetReadBuffer();
+        float[] copy = new float[data.Length];
+        Array.Copy(data, copy, data.Length);
+        SpectrumAvailable?.Invoke(copy);
+    }
+
+    public void Dispose()
+    {
+        Stop();
+    }
+}

--- a/NativeMediaSession/FloatRingBuffer.cs
+++ b/NativeMediaSession/FloatRingBuffer.cs
@@ -1,0 +1,38 @@
+﻿namespace NativeMediaSession;
+
+public class FloatRingBuffer
+{
+    private readonly float[] _buffer;
+    private int _writePos;
+    private int _count;
+
+    public int Count => _count;
+    public int Capacity => _buffer.Length;
+
+    public FloatRingBuffer(int size)
+    {
+        _buffer = new float[size];
+    }
+
+    public void Write(float[] data, int offset, int length)
+    {
+        for (int i = 0; i < length; i++)
+        {
+            _buffer[_writePos] = data[offset + i];
+            _writePos = (_writePos + 1) % _buffer.Length;
+            if (_count < _buffer.Length) _count++;
+        }
+    }
+
+    public void ReadLatest(float[] dest)
+    {
+        if (_count < dest.Length)
+            throw new InvalidOperationException("Not enough data");
+
+        int start = (_writePos - dest.Length + _buffer.Length) % _buffer.Length;
+        for (int i = 0; i < dest.Length; i++)
+        {
+            dest[i] = _buffer[(start + i) % _buffer.Length];
+        }
+    }
+}

--- a/NativeMediaSession/FullMediaState.cs
+++ b/NativeMediaSession/FullMediaState.cs
@@ -1,0 +1,12 @@
+namespace NativeMediaSession;
+
+public record FullMediaState
+{
+    public string title { get; init; } = string.Empty;
+    public string artist { get; init; } = string.Empty;
+    public string albumTitle { get; init; } = string.Empty;
+    public string? albumArtBase64 { get; init; }
+    public string status { get; init; } = string.Empty;
+    public double duration { get; init; }
+    public double position { get; init; }
+}

--- a/NativeMediaSession/GsmtcService.cs
+++ b/NativeMediaSession/GsmtcService.cs
@@ -1,0 +1,148 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Windows.Media.Control;
+using System.Runtime.InteropServices.WindowsRuntime;
+
+namespace NativeMediaSession;
+
+public class GsmtcService : IDisposable
+{
+    private readonly CallbackDispatcher _dispatcher;
+    private readonly MetadataCache _cache;
+    private GlobalSystemMediaTransportControlsSessionManager? _manager;
+    private GlobalSystemMediaTransportControlsSession? _session;
+    private FullMediaState? _last;
+
+    public event Action<FullMediaState>? MetadataAvailable;
+
+    public GsmtcService(CallbackDispatcher dispatcher, MetadataCache cache)
+    {
+        _dispatcher = dispatcher;
+        _cache = cache;
+    }
+
+    public int Start()
+    {
+        try
+        {
+            _manager = GlobalSystemMediaTransportControlsSessionManager.RequestAsync().AsTask().GetAwaiter().GetResult();
+            _manager.CurrentSessionChanged += Manager_CurrentSessionChanged;
+            SubscribeSession();
+            return 0;
+        }
+        catch
+        {
+            Stop();
+            return -5; // gsmtc_error
+        }
+    }
+
+    private void Manager_CurrentSessionChanged(GlobalSystemMediaTransportControlsSessionManager sender, CurrentSessionChangedEventArgs args)
+    {
+        SubscribeSession();
+    }
+
+    private void SubscribeSession()
+    {
+        var session = _manager?.GetCurrentSession();
+        if (session == null)
+            return;
+
+        if (_session != null)
+        {
+            _session.MediaPropertiesChanged -= MediaChanged;
+            _session.PlaybackInfoChanged -= PlaybackChanged;
+            _session.TimelinePropertiesChanged -= TimelineChanged;
+        }
+
+        _session = session;
+        _session.MediaPropertiesChanged += MediaChanged;
+        _session.PlaybackInfoChanged += PlaybackChanged;
+        _session.TimelinePropertiesChanged += TimelineChanged;
+        HandleFullStateChange();
+    }
+
+    private void MediaChanged(GlobalSystemMediaTransportControlsSession session, MediaPropertiesChangedEventArgs args) => HandleFullStateChange();
+    private void PlaybackChanged(GlobalSystemMediaTransportControlsSession session, PlaybackInfoChangedEventArgs args) => HandleFullStateChange();
+    private void TimelineChanged(GlobalSystemMediaTransportControlsSession session, TimelinePropertiesChangedEventArgs args) => HandleFullStateChange();
+
+    private void HandleFullStateChange()
+    {
+        var session = _session;
+        if (session == null) return;
+        try
+        {
+            var state = CreateFullMediaState(session).GetAwaiter().GetResult();
+            if (_last != null && state.Equals(_last)) return;
+            _last = state;
+            _cache.Update(state);
+            _dispatcher.Enqueue(() => MetadataAvailable?.Invoke(state));
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+
+    private async Task<FullMediaState> CreateFullMediaState(GlobalSystemMediaTransportControlsSession session)
+    {
+        var props = await session.TryGetMediaPropertiesAsync();
+        var playback = session.GetPlaybackInfo().PlaybackStatus.ToString();
+        var timeline = session.GetTimelineProperties();
+        double duration = Math.Round(timeline.EndTime.TotalSeconds, 2);
+        double position = Math.Round(timeline.Position.TotalSeconds, 2);
+
+        string? art = null;
+        try
+        {
+            var thumb = props.Thumbnail;
+            if (thumb != null)
+            {
+                using var ms = new MemoryStream();
+                using var stream = await thumb.OpenReadAsync();
+                await stream.AsStreamForRead().CopyToAsync(ms);
+                art = Convert.ToBase64String(ms.ToArray());
+            }
+        }
+        catch
+        {
+        }
+
+        return new FullMediaState
+        {
+            title = props.Title,
+            artist = props.Artist,
+            albumTitle = props.AlbumTitle,
+            albumArtBase64 = art,
+            status = playback,
+            duration = duration,
+            position = position
+        };
+    }
+
+    public void Stop()
+    {
+        try
+        {
+            if (_session != null)
+            {
+                _session.MediaPropertiesChanged -= MediaChanged;
+                _session.PlaybackInfoChanged -= PlaybackChanged;
+                _session.TimelinePropertiesChanged -= TimelineChanged;
+                _session = null;
+            }
+            if (_manager != null)
+            {
+                _manager.CurrentSessionChanged -= Manager_CurrentSessionChanged;
+                _manager = null;
+            }
+        }
+        catch
+        {
+        }
+    }
+
+    public void Dispose() => Stop();
+}
+

--- a/NativeMediaSession/MetadataCache.cs
+++ b/NativeMediaSession/MetadataCache.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace NativeMediaSession;
+
+public class MetadataCache
+{
+    private readonly object _lockObj = new();
+    private FullMediaState? _last;
+
+    public FullMediaState? Last
+    {
+        get { lock (_lockObj) { return _last; } }
+    }
+
+    public void Update(FullMediaState state)
+    {
+        lock (_lockObj)
+        {
+            _last = state;
+        }
+    }
+}

--- a/NativeMediaSession/NativeMediaSession.csproj
+++ b/NativeMediaSession/NativeMediaSession.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnableNativeAot>true</EnableNativeAot>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <UseWinRT>true</UseWinRT>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NAudio" Version="2.2.1" />
+    <PackageReference Include="Microsoft.Windows.SDK.NET" Version="10.0.18362.3-preview" />
+    <PackageReference Include="System.Runtime.WindowsRuntime" Version="4.7.0" />
+  </ItemGroup>
+</Project>

--- a/NativeMediaSession/TripleBuffer.cs
+++ b/NativeMediaSession/TripleBuffer.cs
@@ -1,0 +1,30 @@
+﻿namespace NativeMediaSession;
+
+public class TripleBuffer<T>
+{
+    private readonly T[] _buffers = new T[3];
+    private int _readIndex = 0;
+    private int _writeIndex = 1;
+    private int _standbyIndex = 2;
+    private readonly object _lock = new();
+
+    public TripleBuffer(Func<T> factory)
+    {
+        for (int i = 0; i < 3; i++) _buffers[i] = factory();
+    }
+
+    public T GetWriteBuffer() => _buffers[_writeIndex];
+
+    public void Publish()
+    {
+        lock (_lock)
+        {
+            var tmp = _readIndex;
+            _readIndex = _writeIndex;
+            _writeIndex = _standbyIndex;
+            _standbyIndex = tmp;
+        }
+    }
+
+    public T GetReadBuffer() => _buffers[_readIndex];
+}


### PR DESCRIPTION
## Summary
- create NativeMediaSession project targeting net8.0 win-x64 for NativeAOT interop
- expose basic C ABI exports for init/shutdown/device enumeration/free
- add WASAPI audio service with FFT pipeline and callback subscriptions
- implement GSMTC metadata capture and expose metadata subscription and control exports

## Testing
- `dotnet build NativeMediaSession/NativeMediaSession.csproj -p:EnableWindowsTargeting=true` *(fails: The type 'IAsyncAction' is defined in an assembly that is not referenced. You must add a reference to assembly 'Windows, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null, ContentType=WindowsRuntime')*


------
https://chatgpt.com/codex/tasks/task_e_689a7cf5df388320b2cd2b5e3e57d6ed